### PR TITLE
- defend against null client in `Util`

### DIFF
--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -164,11 +164,11 @@ public class FsActivity extends AppCompatActivity implements
         }
         nav.setItemIconTintList(ColorStateList.valueOf(theme.getAccentColor()));
 
-        if (savedInstanceState == null) {
-            Config config = (Config) intent.getSerializableExtra(FsConstants.EXTRA_CONFIG);
-            String sessionToken = preferences.getString(PREF_SESSION_TOKEN, null);
-            Util.initializeClient(config, sessionToken);
+        Config config = (Config) intent.getSerializableExtra(FsConstants.EXTRA_CONFIG);
+        String sessionToken = preferences.getString(PREF_SESSION_TOKEN, null);
+        Util.initializeClientIfNeeded(config, sessionToken);
 
+        if (savedInstanceState == null) {
             Util.getSelectionSaver().clear();
 
             selectedSource = sources.get(0);

--- a/filestack/src/main/java/com/filestack/android/internal/Util.java
+++ b/filestack/src/main/java/com/filestack/android/internal/Util.java
@@ -203,14 +203,16 @@ public class Util {
     }
 
     /** Create the Java SDK client and set a session token. The token maintains cloud auth state. */
-    public static void initializeClient(Config config, String sessionToken) {
-        // Override returnUrl until introduction of FilestackUi class which will allow to set this
-        // all up manually.
-        Config overridenConfig = new Config(config.getApiKey(), "filestack://done",
-                config.getPolicy(), config.getSignature());
+    public static void initializeClientIfNeeded(Config config, String sessionToken) {
+        if (client == null) {
+            // Override returnUrl until introduction of FilestackUi class which will allow to set this
+            // all up manually.
+            Config overridenConfig = new Config(config.getApiKey(), "filestack://done",
+                    config.getPolicy(), config.getSignature());
 
-        client = new Client(overridenConfig);
-        client.setSessionToken(sessionToken);
+            client = new Client(overridenConfig);
+            client.setSessionToken(sessionToken);
+        }
     }
 
     public static Client getClient() {


### PR DESCRIPTION
Static members get nullified when the process gets killed in the background. We can't assume the `client` is still there just because `savedInstanceState` is not null.